### PR TITLE
Implements 'handleStatusBarWillChange'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Watch and respond to changes in the iOS status bar height.
    [(Screenshot)](http://url.brentvatne.ca/g9Wp).
 4. Follow the example below to use it in JS
 
+### Deprecated `change` Event
+
+The `change` event has been deprecated. The `didChange` event should be used instead.
+It's still available but may be removed in a later version.
+
 ## Example
 
 ```javascript
@@ -22,14 +27,20 @@ var MyApp = React.createClass({
    },
 
    componentDidMount: function() {
-     StatusBarSizeIOS.addEventListener('change', this._handleStatusBarSizeChange);
+     StatusBarSizeIOS.addEventListener('willChange', this._handleStatusBarSizeWillChange);
+     StatusBarSizeIOS.addEventListener('didChange', this._handleStatusBarSizeDidChange);
    },
 
    componentWillUnmount: function() {
-     StatusBarSizeIOS.removeEventListener('change', this._handleStatusBarSizeChange);
+     StatusBarSizeIOS.removeEventListener('willChange', this._handleStatusBarSizeWillChange);
+     StatusBarSizeIOS.removeEventListener('didChange', this._handleStatusBarSizeDidChange);
    },
 
-   _handleStatusBarSizeChange: function(currentStatusBarHeight) {
+   _handleStatusBarSizeWillChange: function(nextStatusBarHeight) {
+     console.log('Will Change: ' + nextStatusBarHeight);
+   },
+
+   _handleStatusBarSizeDidChange: function(currentStatusBarHeight) {
      console.log('changed');
      this.setState({ currentStatusBarHeight: currentStatusBarHeight });
    },
@@ -48,8 +59,4 @@ var MyApp = React.createClass({
 
 ## TODOS
 
-- [ ] Any way to know when status bar change is triggered what is going
-  to happen to it? Will it grow or shrink? To what height? Could be useful to transition with it,
-  otherwise the `willChange` event is a bit pointless (right now this
-  lib only responds to `didChange`)
 - [ ] Update it after device rotation event

--- a/RNStatusBarSize/RNStatusBarSize.m
+++ b/RNStatusBarSize/RNStatusBarSize.m
@@ -26,9 +26,14 @@ RCT_EXPORT_MODULE()
     _lastKnownHeight = RNCurrentStatusBarSize();
 
     [[NSNotificationCenter defaultCenter] addObserver:self
-                                          selector:@selector(handleStatusBarDidChange)
-                                          name:UIApplicationDidChangeStatusBarFrameNotification
-                                          object:nil];
+                                             selector:@selector(handleStatusBarWillChange:)
+                                                 name:UIApplicationWillChangeStatusBarFrameNotification
+                                               object:nil];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleStatusBarDidChange)
+                                                 name:UIApplicationDidChangeStatusBarFrameNotification
+                                               object:nil];
   }
   return self;
 }
@@ -40,6 +45,20 @@ RCT_EXPORT_MODULE()
 }
 
 #pragma mark - App Notification Methods
+
+- (void)handleStatusBarWillChange:(NSNotification *)notification
+{
+  NSValue *rectValue = [[notification userInfo] valueForKey:UIApplicationStatusBarFrameUserInfoKey];
+  
+  CGRect newFrame;
+  [rectValue getValue:&newFrame];
+  
+  float newHeight = newFrame.size.height;
+  if (newHeight != _lastKnownHeight) {
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"statusBarSizeWillChange"
+                             body:@{@"height": [NSNumber numberWithFloat:newHeight]}];
+  }
+}
 
 - (void)handleStatusBarDidChange
 {

--- a/StatusBarSizeIOS.js
+++ b/StatusBarSizeIOS.js
@@ -10,7 +10,11 @@ var RNStatusBarSize = NativeModules.RNStatusBarSize;
 
 var logError = require('logError');
 
-var DEVICE_STATUS_BAR_HEIGHT_EVENT = 'statusBarSizeDidChange';
+var DEVICE_STATUS_BAR_HEIGHT_EVENTS = {
+    willChange: 'statusBarSizeWillChange',
+    didChange: 'statusBarSizeDidChange',
+    change: 'statusBarSizeDidChange'
+};
 
 var _statusBarSizeHandlers = {};
 
@@ -32,12 +36,17 @@ var _statusBarSizeHandlers = {};
  *   };
  * },
  * componentDidMount: function() {
- *   StatusBarSizeIOS.addEventListener('change', this._handleStatusBarSizeChange);
+ *   StatusBarSizeIOS.addEventListener('willChange', this._handleStatusBarSizeWillChange);
+ *   StatusBarSizeIOS.addEventListener('didChange', this._handleStatusBarSizeDidChange);
  * },
  * componentWillUnmount: function() {
- *   StatusBarSizeIOS.removeEventListener('change', this._handleStatusBarSizeChange);
+ *   StatusBarSizeIOS.removeEventListener('willChange', this._handleStatusBarSizeWillChange);
+ *   StatusBarSizeIOS.removeEventListener('didChange', this._handleStatusBarSizeDidChange);
  * },
- * _handleStatusBarSizeChange: function(currentStatusBarHeight) {
+ * _handleStatusBarSizeWillChange: function(upcomingStatusBarHeight) {
+ *   console.log('Upcoming StatusBar Height:' + upcomingStatusBarHeight);
+ * },
+ * _handleStatusBarSizeDidChange: function(currentStatusBarHeight) {
  *   this.setState({ currentStatusBarHeight, });
  * },
  * render: function() {
@@ -53,15 +62,17 @@ var _statusBarSizeHandlers = {};
 var StatusBarSizeIOS = {
 
   /**
-   * Add a handler to Status Bar size changes by listening to the `change` event type
-   * and providing the handler
+   * Add a handler to Status Bar size changes by listening to the event type
+   * and providing the handler.
+   *
+   * Possible event types: change (deprecated), willChange, didChange
    */
   addEventListener: function(
     type: string,
     handler: Function
   ) {
     _statusBarSizeHandlers[handler] = RCTDeviceEventEmitter.addListener(
-      DEVICE_STATUS_BAR_HEIGHT_EVENT,
+      DEVICE_STATUS_BAR_HEIGHT_EVENTS[type],
       (statusBarSizeData) => {
         handler(statusBarSizeData.height);
       }
@@ -69,7 +80,7 @@ var StatusBarSizeIOS = {
   },
 
   /**
-   * Remove a handler by passing the `change` event type and the handler
+   * Remove a handler by passing the event type and the handler
    */
   removeEventListener: function(
     type: string,
@@ -87,7 +98,7 @@ var StatusBarSizeIOS = {
 };
 
 RCTDeviceEventEmitter.addListener(
-  DEVICE_STATUS_BAR_HEIGHT_EVENT,
+  DEVICE_STATUS_BAR_HEIGHT_EVENTS.didChange,
   (statusBarData) => {
     StatusBarSizeIOS.currentHeight = statusBarData.height;
   }


### PR DESCRIPTION
Hey Brent,

I noticed your first ToDo item and figured I'd take a stab at it, I made some assumptions about some of the documentation and the Readme, not sure if that's exactly how you'd like to communicate the changes but I figured I'd go as far as I was able.

Here are the changes as outlined in the commit:
- Uses the `UIApplicationWillChangeStatusBarFrameNotification` notification in accord with
  the `UIApplicationStatusBarFrameUserInfoKey` to get the frame values that the statusBar will apply.
  - https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIApplication_Class/#//apple_ref/c/data/UIApplicationWillChangeStatusBarFrameNotification
- This deprecates the `change` event since we not have `willChange` and `didChange`, however it is still there as to not break backwards compatibility.

Regards,
Dave
