### PR TITLE
Need to require RCTDeviceEventEmitter

### DIFF
--- a/StatusBarSizeIOS.js
+++ b/StatusBarSizeIOS.js
@@ -4,9 +4,8 @@
  */
 'use strict';
 
-var React = require('react-native');
-var { NativeModules, DeviceEventEmitter } = React;
-var RNStatusBarSize = NativeModules.RNStatusBarSize;
+var RNStatusBarSize = require('react-native').NativeModules.RNStatusBarSize;
+var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 
 var DEVICE_STATUS_BAR_HEIGHT_EVENTS = {
   willChange: 'statusBarSizeWillChange',

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
   "author": "Brent Vatne <brentvatne@gmail.com> (https://github.com/brentvatne)",
   "license": "MIT",
   "devDependencies": {
-    "react-native": "^0.4.0"
+    "react-native": "0.8.0"
   },
   "peerDependencies": {
-    "react-native": "^0.4.0"
+    "react-native": "0.8.0"
   }
 }


### PR DESCRIPTION
Introduced by https://github.com/brentvatne/react-native-status-bar-size/commit/20b083705c902a2a902e0d17f8019ebcef6a8b3a.
