### PR TITLE
Fix subscription management leaks

### DIFF
--- a/StatusBarSizeIOS.js
+++ b/StatusBarSizeIOS.js
@@ -13,7 +13,9 @@ var DEVICE_STATUS_BAR_HEIGHT_EVENTS = {
   change: 'statusBarFrameDidChange',
 };
 
-var _statusBarSizeHandlers = {};
+var _statusBarSizeHandlers = Object
+  .keys(DEVICE_STATUS_BAR_HEIGHT_EVENTS)
+  .reduce((obj, key) => ({...obj, [key]: new Map()}), {});
 
 /**
  * `StatusBarSizeIOS` can tell you what the current height of the status bar
@@ -68,12 +70,12 @@ var StatusBarSizeIOS = {
     type: string,
     handler: Function
   ) {
-    _statusBarSizeHandlers[handler] = StatusBarIOS.addListener(
+    _statusBarSizeHandlers[type].set(handler, StatusBarIOS.addListener(
       DEVICE_STATUS_BAR_HEIGHT_EVENTS[type],
       (statusBarData) => {
         handler(statusBarData.frame.height);
       }
-    );
+    ));
   },
 
   /**
@@ -83,11 +85,12 @@ var StatusBarSizeIOS = {
     type: string,
     handler: Function
   ) {
-    if (!_statusBarSizeHandlers[handler]) {
+    var subscription = _statusBarSizeHandlers[type].get(handler);
+    if (!subscription) {
       return;
     }
-    _statusBarSizeHandlers[handler].remove();
-    _statusBarSizeHandlers[handler] = null;
+    subscription.remove();
+    _statusBarSizeHandlers[type].delete(handler);
   },
 
   currentHeight: (null : ?number),


### PR DESCRIPTION
Prior to this PR, event subscriptions were being stored in a plain `Object`, using the handler function as the key. Functions cannot be used as object keys, but when you attempt to do so, instead of receiving an error, `toString()` is called on the function and the resulting string is used as the key. Most functions return the same value for `toString()`, so only one event handler was ever being maintained at a time. The aliasing of all handlers to the same slot in the object was leading to leaks and premature subscription cancellation in `removeEventListener`.

This PR uses a `Map` for bookkeeping, which permits the use of functions as keys. It also fixes the problem raised in #17 where handlers for different event types could potentially be aliased, leading to similar premature unsubscription issues.