### PR TITLE
StatusBarIOS moved to StatusBar to address RN deprecation and removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,18 @@ It's still available but may be removed in a later version.
 var MyApp = React.createClass({
    getInitialState: function() {
      return {
-       currentStatusBarHeight: StatusBarSizeIOS.currentHeight,
+       currentStatusBarHeight: StatusBarSize.currentHeight,
      };
    },
 
    componentDidMount: function() {
-     StatusBarSizeIOS.addEventListener('willChange', this._handleStatusBarSizeWillChange);
-     StatusBarSizeIOS.addEventListener('didChange', this._handleStatusBarSizeDidChange);
+     StatusBarSize.addEventListener('willChange', this._handleStatusBarSizeWillChange);
+     StatusBarSize.addEventListener('didChange', this._handleStatusBarSizeDidChange);
    },
 
    componentWillUnmount: function() {
-     StatusBarSizeIOS.removeEventListener('willChange', this._handleStatusBarSizeWillChange);
-     StatusBarSizeIOS.removeEventListener('didChange', this._handleStatusBarSizeDidChange);
+     StatusBarSize.removeEventListener('willChange', this._handleStatusBarSizeWillChange);
+     StatusBarSize.removeEventListener('didChange', this._handleStatusBarSizeDidChange);
    },
 
    _handleStatusBarSizeWillChange: function(nextStatusBarHeight) {

--- a/StatusBarSize.js
+++ b/StatusBarSize.js
@@ -1,10 +1,10 @@
 /**
- * @providesModule StatusBarSizeIOS
+ * @providesModule StatusBarSize
  * @flow
  */
 'use strict';
 
-const { NativeEventEmitter, StatusBarIOS, NativeModules } = require('react-native');
+const { NativeEventEmitter, StatusBar, NativeModules } = require('react-native');
 const { StatusBarManager } = NativeModules;
 
 var DEVICE_STATUS_BAR_HEIGHT_EVENTS = {
@@ -24,29 +24,29 @@ function getHandlers(type) {
 }
 
 /**
- * `StatusBarSizeIOS` can tell you what the current height of the status bar
+ * `StatusBarSize` can tell you what the current height of the status bar
  * is, so that you can adjust your layout accordingly when a phone call
  * notification comes up, for example.
  *
  * ### Basic Usage
  *
- * To see the current height, you can check `StatusBarSizeIOS.currentHeight`, which
+ * To see the current height, you can check `StatusBarSize.currentHeight`, which
  * will be kept up-to-date. However, `currentHeight` will be null at launch
- * while `StatusBarSizeIOS` retrieves it over the bridge.
+ * while `StatusBarSize` retrieves it over the bridge.
  *
  * ```
  * getInitialState: function () {
  *   return {
- *     currentStatusBarHeight: StatusBarSizeIOS.currentHeight,
+ *     currentStatusBarHeight: StatusBarSize.currentHeight,
  *   };
  * },
  * componentDidMount: function () {
- *   StatusBarSizeIOS.addEventListener('willChange', this._handleStatusBarFrameWillChange);
- *   StatusBarSizeIOS.addEventListener('didChange', this._handleStatusBarFrameDidChange);
+ *   StatusBarSize.addEventListener('willChange', this._handleStatusBarFrameWillChange);
+ *   StatusBarSize.addEventListener('didChange', this._handleStatusBarFrameDidChange);
  * },
  * componentWillUnmount: function () {
- *   StatusBarSizeIOS.removeEventListener('willChange', this._handleStatusBarFrameWillChange);
- *   StatusBarSizeIOS.removeEventListener('didChange', this._handleStatusBarFrameDidChange);
+ *   StatusBarSize.removeEventListener('willChange', this._handleStatusBarFrameWillChange);
+ *   StatusBarSize.removeEventListener('didChange', this._handleStatusBarFrameDidChange);
  * },
  * _handleStatusBarFrameWillChange: function (upcomingStatusBarHeight) {
  *   console.log('Upcoming StatusBar Height:' + upcomingStatusBarHeight);
@@ -64,7 +64,7 @@ function getHandlers(type) {
  * Open up the phone call status bar in the simulator to see it change.
  */
 
-var StatusBarSizeIOS = {
+var StatusBarSize = {
 
   /**
    * Add a handler to Status Bar size changes by listening to the event type
@@ -76,7 +76,7 @@ var StatusBarSizeIOS = {
     type: string,
     handler: (height: number) => mixed
   ) {
-    getHandlers(type).set(handler, StatusBarIOS.addListener(
+    getHandlers(type).set(handler, StatusBar.addListener(
       DEVICE_STATUS_BAR_HEIGHT_EVENTS[type],
       (statusBarData) => {
         handler(statusBarData.frame.height);
@@ -104,10 +104,10 @@ var StatusBarSizeIOS = {
 
 };
 
-StatusBarIOS.addListener(
+StatusBar.addListener(
   DEVICE_STATUS_BAR_HEIGHT_EVENTS.didChange,
   (statusBarData) => {
-    StatusBarSizeIOS.currentHeight = statusBarData.frame.height;
+    StatusBarSize.currentHeight = statusBarData.frame.height;
   }
 );
 
@@ -115,11 +115,11 @@ StatusBarIOS.addListener(
 try {
   StatusBarManager.getHeight(
     (statusBarFrameData) => {
-      StatusBarSizeIOS.currentHeight = statusBarFrameData.height;
+      StatusBarSize.currentHeight = statusBarFrameData.height;
     }
   );
 } catch (e) {
 
 }
 
-module.exports = StatusBarSizeIOS;
+module.exports = StatusBarSize;

--- a/StatusBarSize.js
+++ b/StatusBarSize.js
@@ -6,6 +6,7 @@
 
 const { NativeEventEmitter, StatusBar, NativeModules } = require('react-native');
 const { StatusBarManager } = NativeModules;
+const SBemitter = new NativeEventEmitter(StatusBarManager);
 
 var DEVICE_STATUS_BAR_HEIGHT_EVENTS = {
   willChange: 'statusBarFrameWillChange',
@@ -76,7 +77,7 @@ var StatusBarSize = {
     type: string,
     handler: (height: number) => mixed
   ) {
-    getHandlers(type).set(handler, StatusBar.addListener(
+    getHandlers(type).set(handler, SBemitter.addListener(
       DEVICE_STATUS_BAR_HEIGHT_EVENTS[type],
       (statusBarData) => {
         handler(statusBarData.frame.height);
@@ -104,7 +105,7 @@ var StatusBarSize = {
 
 };
 
-StatusBar.addListener(
+SBemitter.addListener(
   DEVICE_STATUS_BAR_HEIGHT_EVENTS.didChange,
   (statusBarData) => {
     StatusBarSize.currentHeight = statusBarData.frame.height;

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "react-native-status-bar-size",
-  "version": "0.3.3",
+  "version": "0.4.0",
   "description": "Watch and respond to changes in the iOS status bar height",
-  "main": "StatusBarSizeIOS.js",
+  "main": "StatusBarSize.js",
   "repository": {
     "type": "git",
     "url": "git@github.com:jgkim/react-native-status-bar-size.git"
   },
   "files": [
-    "StatusBarSizeIOS.js",
+    "StatusBarSize.js",
     "README.md"
   ],
   "author": "Brent Vatne <brentvatne@gmail.com> (https://github.com/brentvatne/)",


### PR DESCRIPTION
Address RN error: `Warning: StatusBarIOS has been merged with StatusBar and will be removed in a future release. Use StatusBar for mutating the status bar`

- StatusBarSizeIOS module renamed to StatusBarSize accordingly
- hook up emitter and listener, as addListener was available on StatusBarIOS but not on StatusBar
- updated README
- version bumped to 0.4.0
