### PR TITLE
WIP: RN 0.66+ compatibility - 👽 Migrate usage of StatusBarIOS to StatusBar

### DIFF
--- a/StatusBarSizeIOS.js
+++ b/StatusBarSizeIOS.js
@@ -4,7 +4,7 @@
  */
 'use strict';
 
-const { NativeEventEmitter, StatusBarIOS, NativeModules } = require('react-native');
+const { NativeEventEmitter, StatusBar, NativeModules } = require('react-native');
 const { StatusBarManager } = NativeModules;
 
 var DEVICE_STATUS_BAR_HEIGHT_EVENTS = {
@@ -76,7 +76,7 @@ var StatusBarSizeIOS = {
     type: string,
     handler: (height: number) => mixed
   ) {
-    getHandlers(type).set(handler, StatusBarIOS.addListener(
+    getHandlers(type).set(handler, StatusBar.addListener(
       DEVICE_STATUS_BAR_HEIGHT_EVENTS[type],
       (statusBarData) => {
         handler(statusBarData.frame.height);
@@ -104,7 +104,7 @@ var StatusBarSizeIOS = {
 
 };
 
-StatusBarIOS.addListener(
+StatusBar.addListener(
   DEVICE_STATUS_BAR_HEIGHT_EVENTS.didChange,
   (statusBarData) => {
     StatusBarSizeIOS.currentHeight = statusBarData.frame.height;


### PR DESCRIPTION
As of react-native 0.66, StatusBarIOS has been removed from React Native and has been merged with StatusBar. 

Unfortunately, RN has not yet migrated the events from StatusBarIOS to StatusBar. Therefore this fix is not yet viable.
Once events are migrated from RN's side, this fix shall work.

closes: https://github.com/jgkim/react-native-status-bar-size/issues/23
Pending RN issue: https://github.com/facebook/react-native/issues/32297